### PR TITLE
Add nrepl-server to :dev alias

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/deps.edn
+++ b/libs/lein-template/resources/leiningen/new/kit/deps.edn
@@ -53,9 +53,11 @@
                                 pjstadig/humane-test-output     {:mvn/version "0.11.0"}
                                 ring/ring-devel                 {:mvn/version "1.9.4"}
                                 ring/ring-mock                  {:mvn/version "0.4.0"}
+                                nrepl/nrepl                     {:mvn/version "0.9.0"}
+                                cider/cider-nrepl               {:mvn/version "0.28.0"}
                                 io.github.kit-clj/kit-generator {:mvn/version "<<versions.kit-generator>>"}}
                   :extra-paths ["env/dev/clj" "env/dev/resources" "test/clj"]
-                  :main-opts   ["-e" "(require 'pjstadig.humane-test-output) (pjstadig.humane-test-output/activate!)" "-r"]}
+                  :main-opts   ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]" "-i"]}
 
            :test {:extra-deps  {criterium/criterium                  {:mvn/version "0.4.6"}
                                 expound/expound                      {:mvn/version "0.8.9"}


### PR DESCRIPTION
Add nrepl.cmdline to :dev alias.

When starting application with `clj -M:dev` interactive repl session will be started, as well as `nrepl-server` on random free port.

The implementation outsource to `nrepl.cmdline` utility function of nrepl.

Fully functional repl could be implemented in the future using `reply` library, the same that is used by `lein repl` and `boot repl`, but I had some issues with it when trying to use it.