### PR TITLE
Clarifying template README

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/README.md
+++ b/libs/lein-template/resources/leiningen/new/kit/README.md
@@ -8,11 +8,11 @@ Start the server with:
 (go)
 ```
 
-The default API is found at localhost:3000/api
+The default API is available under http://localhost:3000/api
 
-System configuration is found under `resources/system.edn`
+System configuration is available under `resources/system.edn`.
 
-Reload changes:
+To reload changes:
 
 ```clojure
 (reset)
@@ -22,12 +22,16 @@ Reload changes:
 
 ### Cursive
 
-Configure a [REPL following the Cursive documentation](https://cursive-ide.com/userguide/repl.html). Using the default "Run with IntelliJ project classpath" will let you select your profiles from the ["Clojure deps" aliases selection](https://cursive-ide.com/userguide/deps.html#refreshing-deps-dependencies)
+Configure a [REPL following the Cursive documentation](https://cursive-ide.com/userguide/repl.html). Using the default "Run with IntelliJ project classpath" option will let you select an alias from the ["Clojure deps" aliases selection](https://cursive-ide.com/userguide/deps.html#refreshing-deps-dependencies).
 
 ### CIDER
 
-Use the profile `cider` for CIDER nREPL support. See the [CIDER docs](https://docs.cider.mx/cider/basics/up_and_running.html) for more help.
+Use the `cider` alias for CIDER nREPL support (run `clj -M:dev:cider`). See the [CIDER docs](https://docs.cider.mx/cider/basics/up_and_running.html) for more help.
+
+Note that this alias runs nREPL during development. To run nREPL in production (typically when the system starts), use the kit-nrepl library through the +nrepl profile as described in [the documentation](https://kit-clj.github.io/docs/profiles.html#profiles).
 
 ### Command Line
 
-Run `clj -M:dev:nrepl` or `make repl`
+Run `clj -M:dev:nrepl` or `make repl`.
+
+Note that, just like with [CIDER](#cider), this alias runs nREPL during development. To run nREPL in production (typically when the system starts), use the kit-nrepl library through the +nrepl profile as described in [the documentation](https://kit-clj.github.io/docs/profiles.html#profiles).


### PR DESCRIPTION
Minor clarifications to the README as I mentioned in #15

For Cursive, I was not able to select an alias from deps myself so I'm not 100% sure this instruction is correct (there was no dropdown, or anything). I'm not a Cursive user but I still managed to create a manual configuration by choosing clojure.main as my REPL and selecting "Run with IntelliJ project classpath" as instructed. 