### PR TITLE
Add watch-deps ns to :require

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/env/dev/clj/user.clj
+++ b/libs/lein-template/resources/leiningen/new/kit/env/dev/clj/user.clj
@@ -10,6 +10,7 @@
     [integrant.repl :refer [clear go halt prep init reset reset-all]]
     [integrant.repl.state :as state]
     [kit.api :as kit]
+  #_[lambdaisland.classpath.watch-deps :as watch-deps] ;; hot loading for deps
     [<<ns-name>>.core :refer [start-app]]))
 
 ;; uncomment to enable hot loading for deps


### PR DESCRIPTION
Missing watch-deps namespace in user.clj causing error: `No such namespace: watch-deps` when trying to enable hot loading for deps