### PR TITLE
fix session map cookie-name

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/resources/system.edn
+++ b/libs/lein-template/resources/leiningen/new/kit/resources/system.edn
@@ -36,8 +36,8 @@
                                       :keywordize true}
                           :cookies   true
                           :session   {:flash true
-                                      :cookie-attrs {:cookie-name "<<ns-name>>"
-                                                     :max-age     86400
+                                      :cookie-name "<<ns-name>>"
+                                      :cookie-attrs {:max-age     86400
                                                      :http-only   true
                                                      :same-site   :strict}}
                           :security  {:anti-forgery   false


### PR DESCRIPTION
Related to this change https://github.com/kit-clj/kit/pull/41

The `:cookie-name` should not be inside `:cookie-attrs` based on the [ring.middleware.session/wrap-session](https://github.com/ring-clojure/ring/blob/master/ring-core/src/ring/middleware/session.clj#L94-L99)
