### PR TITLE
Add full command name `kit/sync-modules to list-modules

### DIFF
--- a/libs/kit-generator/src/kit/generator/modules.clj
+++ b/libs/kit-generator/src/kit/generator/modules.clj
@@ -46,7 +46,7 @@
 (defn list-modules [ctx]
   (let [modules (-> ctx :modules :modules)]
     (if (empty? modules)
-      (println "No modules installed, maybe run `sync-modules`")
+      (println "No modules installed, maybe run `(kit/sync-modules)`")
       (doseq [[id {:keys [doc]}] modules]
         (println id "-" doc)))))
 


### PR DESCRIPTION
help message when no modules are present

Why:
The original message may cause unecessery confusion for new developers.
Example:
```
user> (kit/list-modules)
No modules installed, maybe run `sync-modules`
:done
user> (sync-modules)
Syntax error compiling at (*cider-repl clojure/foo:localhost:45381(clj)*:11685:7).
user> sync-modules
Syntax error compiling at (*cider-repl clojure/foo:localhost:45381(clj)*:0:0).
user> (kit/sync-modules)
:done
```