### PR TITLE
Fixed :start keys in env defaults

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/env/dev/clj/env.clj
+++ b/libs/lein-template/resources/leiningen/new/kit/env/dev/clj/env.clj
@@ -6,7 +6,7 @@
 (def defaults
   {:init       (fn []
                  (log/info "\n-=[<<app>> starting using the development or test profile]=-"))
-   :started    (fn []
+   :start      (fn []
                  (log/info "\n-=[<<app>> started successfully using the development or test profile]=-"))
    :stop       (fn []
                  (log/info "\n-=[<<app>> has shut down successfully]=-"))

--- a/libs/lein-template/resources/leiningen/new/kit/env/prod/clj/env.clj
+++ b/libs/lein-template/resources/leiningen/new/kit/env/prod/clj/env.clj
@@ -4,7 +4,7 @@
 (def defaults
   {:init       (fn []
                  (log/info "\n-=[<<app>> starting]=-"))
-   :started    (fn []
+   :start      (fn []
                  (log/info "\n-=[<<app>> started successfully]=-"))
    :stop       (fn []
                  (log/info "\n-=[<<app>> has shut down successfully]=-"))

--- a/libs/lein-template/resources/leiningen/new/kit/src/clj/web/middleware/core.clj
+++ b/libs/lein-template/resources/leiningen/new/kit/src/clj/web/middleware/core.clj
@@ -2,7 +2,7 @@
   (:require
     [<<ns-name>>.env :as env]
     [ring.middleware.defaults :as defaults]
-    [ring.middleware.session.cookie :as cookie] <% if metrics? %>
+    [ring.middleware.session.cookie :as cookie]<% if metrics? %>
     [iapetos.collector.ring :as prometheus-ring]<% endif %>))
 
 (defn wrap-base


### PR DESCRIPTION
[`<<ns-name>>.core`](https://github.com/kit-clj/kit/blob/master/libs/lein-template/resources/leiningen/new/kit/src/clj/core.clj#L46) uses `:start`.

(And snuck in a minor whitespace fix.)