### PR TITLE
git ignore downloaded kit modules

### DIFF
--- a/libs/lein-template/resources/leiningen/new/kit/gitignore
+++ b/libs/lein-template/resources/leiningen/new/kit/gitignore
@@ -7,6 +7,7 @@ target
 log/
 .shadow-cljs/
 node_modules/
+modules/
 
 # IntelliJ
 *.iml


### PR DESCRIPTION
I'm not sure about this one, but the `modules/` dir doesn't seem like something to track in a kit project's git repo. Especially since `modules/kit-modules` is a git repo checkout.