### PR TITLE
Sync lib deps during publishing

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -24,7 +24,7 @@
   ;; kit-mysql
   mysql/mysql-connector-java             {:mvn/version "8.0.29"}
   ;; kit-nrepl
-  nrepl/nrepl                            {:mvn/version "0.9.0"}
+  nrepl/nrepl                            {:mvn/version "1.0.0"}
   ;; kit-postgres
   org.postgresql/postgresql              {:mvn/version "42.3.4"}
   cheshire/cheshire                      {:mvn/version "5.10.2"}
@@ -41,7 +41,7 @@
   io.github.kit-clj/kit-sql-conman       {:mvn/version "1.0.2"}
   io.github.kit-clj/kit-sql-migratus     {:mvn/version "1.0.0"}
   ;; kit-sql-conman
-  conman/conman                          {:mvn/version "0.9.4"}
+  conman/conman                          {:mvn/version "0.9.5"}
   ;; kit-sql-hikari
   com.github.seancorfield/next.jdbc      {:mvn/version "1.2.780"}
   hikari-cp/hikari-cp                    {:mvn/version "2.14.0"}

--- a/build.clj
+++ b/build.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.tools.build.api :as b]
    [clojure.java.io :as jio]
-   [clojure.java.shell :refer [sh]]
    [clojure.edn :as edn]
    [clojure.pprint :refer [pprint]]
    [weavejester.dependency :as dep]

--- a/build/kit/sync_lib_deps.clj
+++ b/build/kit/sync_lib_deps.clj
@@ -1,9 +1,9 @@
-#!/usr/bin/env bb
-
-(require '[rewrite-clj.zip :as z]
-         '[clojure.java.io :as io]
-         '[clojure.edn :as edn]
-         '[babashka.fs :as fs])
+(ns kit.sync-lib-deps
+  (:require [rewrite-clj.zip :as z]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [babashka.fs :as fs]
+            [clojure.set :as set]))
 
 (def enabled-libs
   ["kit-core"
@@ -64,16 +64,30 @@
             (transform-deps (z/next zloc) dependencies)
             (recur zloc)))))))
 
-(doseq [lib  enabled-libs
-          path (fs/glob (str "libs/" lib) "deps.edn")
-          :let [f (io/file (str path))]]
-    (println (str path))
-    (when-not (.exists (io/file f))
-      (println "File does not exist" f)
-      (System/exit 1))
-    (let [updated (str (replace-dependencies (slurp f) dependencies))]
-      #_(println updated)
-      (spit f updated)))
+(defn sync-lib-deps [& {:as opts}]
+  (->> (for [lib  (if (seq (:libs opts))
+                    (set/intersection (set enabled-libs) (set (:libs opts)))
+                    enabled-libs)
+             path (fs/glob (str "libs/" lib) "deps.edn")
+             :let [f (io/file (str path))]]
+         (do
+           (when-not (.exists (io/file f))
+             (println "File does not exist" f)
+             (System/exit 1))
+           (let [original (slurp f)
+                 updated (str (replace-dependencies original dependencies))]
+             (when (not= original updated)
+               (println (str path))
+               (spit f updated)
+               (str path)))))
+       (remove nil?)
+       doall))
+
+(defn -main [& _]
+  (sync-lib-deps))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))
 
 (comment
   (def test-code

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,8 @@
            :build {:deps {io.github.clojure/tools.build {:git/sha "7d40500"
                                                          :git/tag "v0.8.1" :git/url "https://github.com/clojure/tools.build.git"}
                           slipset/deps-deploy {:mvn/version "0.2.0"}
-                          weavejester/dependency {:mvn/version "0.2.1"}}
-                   :ns-default build}}
- }
+                          weavejester/dependency {:mvn/version "0.2.1"}
+                          rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
+                          babashka/fs {:mvn/version "0.1.11"}}
+                   :extra-paths ["build"]
+                   :ns-default build}}}

--- a/justfile
+++ b/justfile
@@ -22,4 +22,4 @@ antq:
 
 # writes dependencies from bb.edn to each lib
 sync-deps:
-  bb sync-lib-deps.clj
+  bb build/kit/sync_lib_deps.clj

--- a/sync-lib-deps.clj
+++ b/sync-lib-deps.clj
@@ -2,6 +2,7 @@
 
 (require '[rewrite-clj.zip :as z]
          '[clojure.java.io :as io]
+         '[clojure.edn :as edn]
          '[babashka.fs :as fs])
 
 (def enabled-libs
@@ -19,10 +20,14 @@
    "kit-sql"
    "kit-sql-conman"
    "kit-undertow"
-   "kit-xtdb"])
+   "kit-xtdb"
+   "lein-template"])
+
+(def versions (edn/read-string (slurp "./libs/deps-template/resources/io/github/kit_clj/kit/versions.edn")))
 
 (def dependencies
-  (:deps (edn/read-string (slurp "bb.edn"))))
+  (merge (:deps (edn/read-string (slurp "bb.edn")))
+         {'io.github.kit-clj/deps-template {:mvn/version (get versions "deps-template")}}))
 
 (defn deps-token?
   [zloc]


### PR DESCRIPTION
- Update `sync-lib-deps` so it can be used from `build.clj`
- Use `versions.edn` for the `deps-template` version within `lein-template`
- Allow syncing of one lib at a time for `build.clj` usage
- Update outdated deps in `bb.edn`
- Run `sync-lib-deps` when attempting to install a lib and print an error when changes need to be committed