### PR TITLE
Improvements to `sync-lib-deps` integration in `build.clj`

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -11,7 +11,7 @@
                    (apply clojure args)))
          publish-local (clj "-T:build install-lib" :artifact-id lib)
          publish (clj "-T:build install-lib" :artifact-id lib :publish true)
-         publish-all-local (clj "-T:build install-libs" :publish false)
+         publish-all-local (clj "-T:build all" :publish false)
          antq (clj
                 "-Sdeps '{:deps {com.github.liquidz/antq {:mvn/version \"RELEASE\"}}}'"
                 "-M" "-m" "antq.core" "-d" "build")

--- a/build.clj
+++ b/build.clj
@@ -46,7 +46,7 @@
 
 (defn- assert-clean-working-directory []
   (when-not (git-clean-working-directory? (git-status))
-    (throw (ex-info "All changes must be committed before publishing." {}))))
+    (throw (ex-info "All changes must be committed before building." {}))))
 
 (defn make-jar
   "Create the jar from a source pom and source files"

--- a/build/deps.edn
+++ b/build/deps.edn
@@ -3,7 +3,7 @@
   aero/aero                              {:mvn/version "1.1.6"}
   integrant/integrant                    {:mvn/version "0.8.0"}
   org.clojure/tools.logging              {:mvn/version "1.2.4"}
-  ch.qos.logback/logback-classic         {:mvn/version "1.2.11"}
+  ch.qos.logback/logback-classic         {:mvn/version "1.4.4"}
   com.lambdaisland/classpath             {:mvn/version "0.0.27"}
   ;; kit-hato
   hato/hato                              {:mvn/version "0.8.2"}

--- a/build/kit/sync_lib_deps.clj
+++ b/build/kit/sync_lib_deps.clj
@@ -77,9 +77,8 @@
            (let [original (slurp f)
                  updated (str (replace-dependencies original dependencies))]
              (when (not= original updated)
-               (println (str path))
-               (spit f updated)
-               (str path)))))
+               (spit f updated))
+             (str path))))
        (remove nil?)
        doall))
 


### PR DESCRIPTION
Right now the `build.clj` script does run `sync-lib-deps`, but it only causes the build to fail the first time it runs.

This PR updates the `build.clj` script to check for changes in Git before building. If there are uncommitted changes, you'll get an error message:

```
$ bb publish-all-local
+ clojure -T:build all :publish false
Syncing lib deps...
libs/kit-core/deps.edn

Execution error (ExceptionInfo) at build/assert-clean-working-directory (build.clj:49).
All changes must be committed before building.

Full report at:
/var/folders/tt/73f6l1j971n03fsxstmz_g280000gn/T/clojure-3948577615227481739.edn
Error while executing task: publish-all-local
```

I figure this is better than trying to commit changes automatically. This check isn't specific to `sync-lib-deps` so it will also work if other pre-build scripts are added in the future.