### PR TITLE
fix call to clj-jgit.porcelain/git-clone

### DIFF
--- a/libs/kit-generator/src/kit/generator/git.clj
+++ b/libs/kit-generator/src/kit/generator/git.clj
@@ -32,10 +32,10 @@
             (git/git-pull repo))
           (catch FileNotFoundException _e
             (git/git-clone url :dir                path
-                               :remote-name        "origin"
-                               :branch-name        (or tag "master")
-                               :bare               false
-                               :clone-all-branches false)))
+                               :remote             "origin"
+                               :branch             (or tag "master")
+                               :bare?              false
+                               :clone-all?         false)))
         (when callback (callback path))))
     (catch Exception e
       (println "failed to clone module:" url "\ncause:" (.getMessage e))


### PR DESCRIPTION
clj-jgit has annoyingly changed the name of keyword arguments to their clone function which breaks kit when you specify custom module tag etc.  I created a kit project and then ran

(doc git/git-clone)
-------------------------
clj-jgit.porcelain/git-clone
([uri & {:keys [bare? branch callback clone-all? clone-branches clone-subs? dir git-dir no-checkout? mirror? monitor remote tags], :or {branch "master", callback nil, remote nil, tags :auto-follow, bare? false, clone-branches nil, dir nil, mirror? false, clone-subs? false, clone-all? true, git-dir nil, no-checkout? false, monitor nil}}])
  Clone a repository into a new working directory from given `uri`.

    Options:

    :bare?          Whether the cloned repository shall be bare. (default: false)
    :branch         The initial branch to check out when cloning the repository. Can be
                    specified as ref name ("refs/heads/master"), branch name
                    ("master") or tag name ("v1.2.3"). If set to nil "HEAD"
                    is used. (default: "master")
    :callback       Register a progress callback. See JGit CloneCommand.Callback
                    interface. (default: nil)
    :clone-all?     Whether all branches have to be fetched. (default: true)
    :clone-branches String or coll of strings of branch(es) to clone. Ignored when
                    :clone-all? is true. Branches must be specified as full ref
                    names (e.g. "refs/heads/master"). (default: nil)
    :clone-subs?    If true; initialize and update submodules. Ignored when :bare?
                    is true. (default: false)
    :dir            The optional directory associated with the clone operation. If
                    the directory isn't set, a name associated with the source uri
                    will be used. (default: nil)
    :git-dir        The repository meta directory (.git). (default: nil = automatic)
    :no-checkout?   If set to true no branch will be checked out after the clone.
                    This enhances performance of the clone command when there is no
                    need for a checked out branch. (default: false)
    :mirror?        Set up a mirror of the source repository. This implies that a
                    bare repository will be created. Compared to :bare?, :mirror?
                    not only maps local branches of the source to local branches of
                    the target, it maps all refs (including remote-tracking branches,
                    notes etc.) and sets up a refspec configuration such that all
                    these refs are overwritten by a git remote update in the target
                    repository. (default: false)
    :monitor        Set a progress monitor. See JGit ProgressMonitor interface.
                    (default: nil)
    :remote         The remote name used to keep track of the upstream repository for the
                    clone operation. If no remote name is set, "origin" is used.
                    (default: nil)
    :tags           Set the tag option used for the remote configuration explicitly.
                    Options:
                      :auto-follow  - Automatically follow tags if we fetch the thing they point at.
                      :fetch-tags   - Always fetch tags, even if we do not have the thing it points at.
                      :no-tags      - Never fetch tags, even if we have the thing it points at.
                    (default: :auto-follow)
