### PR TITLE
Add dir-locals for CIDER integration

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/.dir-locals.el
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/.dir-locals.el
@@ -1,0 +1,2 @@
+(nil . ((cider-clojure-cli-aliases . ":dev:cider")
+        (cider-preferred-build-tool . clojure-cli)))


### PR DESCRIPTION
This change should allow emacs users to jack in from an out-of-the-box kit template.