### PR TITLE
Scope dir-locals vars to clojure-mode only

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/.dir-locals.el
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/.dir-locals.el
@@ -1,2 +1,2 @@
-(nil . ((cider-clojure-cli-aliases . ":dev:cider")
-        (cider-preferred-build-tool . clojure-cli)))
+((clojure-mode . ((cider-clojure-cli-aliases . ":dev:cider")
+                  (cider-preferred-build-tool . clojure-cli))))


### PR DESCRIPTION
Previous commit was incorrect anyway, since it was supposed to be a list of lists. Scoping explicitly to clojure-mode also works around bugs in doom emacs / envrc hook priority, where dir-locals are immediately loaded, and then clobbered into nothingness when the envrc major mode loads. Setting the major-mode scope for these variables works around the issue as envrc is explicitly hooked in before other major-modes load, effectively deferring dir-locals until after the direnv loads and thus having the correct additive effect.