### PR TITLE
<<app>> appears unused, replace with <<ns-name>>

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/env.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/env.clj
@@ -5,11 +5,11 @@
 
 (def defaults
   {:init       (fn []
-                 (log/info "\n-=[<<app>> starting using the development or test profile]=-"))
+                 (log/info "\n-=[<<ns-name>> starting using the development or test profile]=-"))
    :start      (fn []
-                 (log/info "\n-=[<<app>> started successfully using the development or test profile]=-"))
+                 (log/info "\n-=[<<ns-name>> started successfully using the development or test profile]=-"))
    :stop       (fn []
-                 (log/info "\n-=[<<app>> has shut down successfully]=-"))
+                 (log/info "\n-=[<<ns-name>> has shut down successfully]=-"))
    :middleware wrap-dev
    :opts       {:profile       :dev
                 :persist-data? true}})

--- a/libs/deps-template/resources/io/github/kit_clj/kit/env/prod/clj/env.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/env/prod/clj/env.clj
@@ -3,10 +3,10 @@
 
 (def defaults
   {:init       (fn []
-                 (log/info "\n-=[<<app>> starting]=-"))
+                 (log/info "\n-=[<<ns-name>> starting]=-"))
    :start      (fn []
-                 (log/info "\n-=[<<app>> started successfully]=-"))
+                 (log/info "\n-=[<<ns-name>> started successfully]=-"))
    :stop       (fn []
-                 (log/info "\n-=[<<app>> has shut down successfully]=-"))
+                 (log/info "\n-=[<<ns-name>> has shut down successfully]=-"))
    :middleware (fn [handler _] handler)
    :opts       {:profile :prod}})


### PR DESCRIPTION
On a new project, I got the following in `<<ns-name>>.env`:
```(def defaults
  {:init       (fn []
                 (log/info "\n-=[ starting]=-"))
   :start      (fn []
                 (log/info "\n-=[ started successfully]=-"))
   :stop       (fn []
                 (log/info "\n-=[ has shut down successfully]=-"))
   :middleware (fn [handler _] handler)
   :opts       {:profile :prod}})
```

Looks like the templating is not quite right. Replaced with <<ns-name>>, let me know if this isn't intended.