### PR TITLE
refactored resource access in routes

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/routes/api.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/routes/api.clj
@@ -10,6 +10,27 @@
     [reitit.ring.middleware.parameters :as parameters]
     [reitit.swagger :as swagger]))
 
+(def route-data
+  {:coercion   malli/coercion
+   :muuntaja   formats/instance
+   :swagger    {:id ::api}
+   :middleware [;; query-params & form-params
+                parameters/parameters-middleware
+                  ;; content-negotiation
+                muuntaja/format-negotiate-middleware
+                  ;; encoding response body
+                muuntaja/format-response-middleware
+                  ;; exception handling
+                coercion/coerce-exceptions-middleware
+                  ;; decoding request body
+                muuntaja/format-request-middleware
+                  ;; coercing response bodys
+                coercion/coerce-response-middleware
+                  ;; coercing request parameters
+                coercion/coerce-request-middleware
+                  ;; exception handling
+                exception/wrap-exception]})
+
 ;; Routes
 (defn api-routes [_opts]
   [["/swagger.json"
@@ -19,34 +40,10 @@
    ["/health"
     {:get health/healthcheck!}]])
 
-(defn route-data
-  [opts]
-  (merge
-    opts
-    {:coercion   malli/coercion
-     :muuntaja   formats/instance
-     :swagger    {:id ::api}
-     :middleware [;; query-params & form-params
-                  parameters/parameters-middleware
-                  ;; content-negotiation
-                  muuntaja/format-negotiate-middleware
-                  ;; encoding response body
-                  muuntaja/format-response-middleware
-                  ;; exception handling
-                  coercion/coerce-exceptions-middleware
-                  ;; decoding request body
-                  muuntaja/format-request-middleware
-                  ;; coercing response bodys
-                  coercion/coerce-response-middleware
-                  ;; coercing request parameters
-                  coercion/coerce-request-middleware
-                  ;; exception handling
-                  exception/wrap-exception]}))
-
 (derive :reitit.routes/api :reitit/routes)
 
 (defmethod ig/init-key :reitit.routes/api
   [_ {:keys [base-path]
       :or   {base-path ""}
       :as   opts}]
-  [base-path (route-data opts) (api-routes opts)])
+  [base-path route-data (api-routes opts)])


### PR DESCRIPTION
This change removes Integrant `opts` from `route-data` since `opts` are already accessible directly in `api-routes`.

TODO: update documentation and sample projects to match this change.