### PR TITLE
Add explicit test-runner `:git/url`

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
@@ -64,7 +64,8 @@
            :test {:extra-deps  {criterium/criterium                  {:mvn/version "0.4.6"}
                                 expound/expound                      {:mvn/version "0.9.0"}
                                 integrant/repl                       {:mvn/version "0.3.2"}
-                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.0"
+                                io.github.cognitect-labs/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                                      :git/tag "v0.5.0"
                                                                       :git/sha "b3fd0d2"}
                                 pjstadig/humane-test-output          {:mvn/version "0.11.0"}
                                 ring/ring-devel                      {:mvn/version "1.9.5"}


### PR DESCRIPTION
This can help other tooling (which can read deps.edn) know the url.

Cheers - V