### PR TITLE
Address CVEs in deps.edn template

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
@@ -4,11 +4,11 @@
  :deps    {org.clojure/clojure             {:mvn/version "1.11.1"}
 
            ;; Routing
-           metosin/reitit                  {:mvn/version "0.5.18"}
+           metosin/reitit                  {:mvn/version "0.6.0"}
 
            ;; Ring
            metosin/ring-http-response      {:mvn/version "0.9.3"}
-           ring/ring-core                  {:mvn/version "1.9.5"}
+           ring/ring-core                  {:mvn/version "1.10.0"}
            ring/ring-defaults              {:mvn/version "0.3.3"}
 
            ;; Logging


### PR DESCRIPTION
Per nvd-clojure:

```
+-------------------------------+--------------------------------+
| dependency                    | status                         |
+-------------------------------+--------------------------------+
| commons-fileupload-1.4.jar    | CVE-2023-24998                 |
| jackson-databind-2.13.2.2.jar | CVE-2022-42004, CVE-2022-42003 |
+-------------------------------+--------------------------------+
```

Cheers - V