### PR TITLE
adds teardown step for test system-fixture

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/test_utils.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/test_utils.clj
@@ -12,4 +12,5 @@
   (fn [f]
     (when (nil? (system-state))
       (core/start-app {:opts {:profile :test}}))
-    (f)))
+    (f)
+    (core/stop-app)))


### PR DESCRIPTION
I noticed that the system-fixture was missing a teardown step for testing.

I added a few high level API tests for my hobby project with mock.ring.request and used `utils/system-fixture` and `utils/system-state` from the `test_utils.clj` to configure my database and handler. The tests passed, but I noticed that when I ran `clj -X:test` from the CLI the process would hang, or if ran the `(run-tests)` function in the repl mutiple times I would get a "bind address already in use" error.

I figure the fixture starts up the whole integrant system including the http-server, which doesn't exit. In any case, adding this teardown step worked locally for me, and seems to align with the practices listed on the [use-fixtures documentation](https://clojuredocs.org/clojure.test/use-fixtures).

I don't know clojure super well yet so not sure if there is a better way to be doing this, but figured I would open a PR since this was helpful for me.