### PR TITLE
Make nREPL server persist over resets

### DIFF
--- a/libs/kit-nrepl/deps.edn
+++ b/libs/kit-nrepl/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src"]
  :deps  {org.clojure/tools.logging {:mvn/version "1.2.4"}
          integrant/integrant       {:mvn/version "0.8.1"}
-         nrepl/nrepl               {:mvn/version "1.0.0"}}}
+         nrepl/nrepl               {:mvn/version "1.0.0"}
+         io.github.kit-clj/kit-core {:mvn/version "1.0.4"}}}

--- a/libs/kit-nrepl/src/kit/edge/utils/nrepl.clj
+++ b/libs/kit-nrepl/src/kit/edge/utils/nrepl.clj
@@ -2,6 +2,7 @@
   (:require
     [clojure.tools.logging :as log]
     [integrant.core :as ig]
+    [kit.ig-utils :as ig-utils]
     [nrepl.server :as nrepl]))
 
 (defmethod ig/init-key :nrepl/server
@@ -16,7 +17,13 @@
       (log/error "failed to start the nREPL server on port:" port)
       (throw e))))
 
+(defmethod ig/suspend-key! :nrepl/server [_ _])
+
 (defmethod ig/halt-key! :nrepl/server
   [_ {::keys [server]}]
   (nrepl/stop-server server)
   (log/info "nREPL server stopped"))
+
+(defmethod ig/resume-key :nrepl/server
+  [key opts old-opts old-impl]
+  (ig-utils/resume-handler key opts old-opts old-impl))

--- a/libs/kit-nrepl/src/kit/edge/utils/nrepl.clj
+++ b/libs/kit-nrepl/src/kit/edge/utils/nrepl.clj
@@ -3,14 +3,17 @@
     [clojure.tools.logging :as log]
     [integrant.core :as ig]
     [kit.ig-utils :as ig-utils]
+    [nrepl.cmdline]
     [nrepl.server :as nrepl]))
 
 (defmethod ig/init-key :nrepl/server
-  [_ {:keys [port bind ack-port] :as config}]
+  [_ {:keys [port bind ack-port create-nrepl-port-file?] :as config}]
   (try
     (let [server (nrepl/start-server :port port
                                      :bind bind
                                      :ack-port ack-port)]
+      (when create-nrepl-port-file?
+        (nrepl.cmdline/save-port-file server {}))
       (log/info "nREPL server started on port:" port)
       (assoc config ::server server))
     (catch Exception e


### PR DESCRIPTION
fixes https://github.com/kit-clj/kit/issues/91

Mostly inspired by how this is done in other components, tested it in the REPL with `integrant.repl/reset` with something like this:

```clj
 (require '[integrant.repl :as igr])
 (igr/set-prep! #(ig/prep {:nrepl/server {:port 4004}}))
 (igr/reset)
```

--- 

I also added another commit (happy to open a separate PR or remove it) but just wanted to check in about the idea: I usually start my development system via something like `bb dev` this will launch an nREPL server that I then connect to. I think with kit it could make sense to do something similar and only inject that component in development? 