### PR TITLE
Refrain from re-initializing query-fn if queries files not modified

### DIFF
--- a/libs/kit-core/src/kit/ig_utils.clj
+++ b/libs/kit-core/src/kit/ig_utils.clj
@@ -1,8 +1,10 @@
 (ns kit.ig-utils
   "Integrant utilities"
   (:require
+    [clojure.java.io :as io]
     [clojure.tools.logging :as log]
-    [integrant.core :as ig]))
+    [integrant.core :as ig])
+  (:import (java.nio.file Files LinkOption Paths)))
 
 (defn resume-handler
   "Useful where you don't want to reset an integrant component in development"
@@ -12,3 +14,9 @@
     old-impl
     (do (ig/halt-key! k old-impl)
         (ig/init-key k opts))))
+
+(defn last-modified [filename]
+  (-> (io/resource filename) (.toURI)
+      (Paths/get)
+      (Files/getLastModifiedTime (into-array LinkOption []))
+      (.toMillis)))

--- a/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
+++ b/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
@@ -23,8 +23,23 @@
       :or   {options {}}}]
   (let [filenames (or filenames [filename])
         queries (apply conman/bind-connection-map conn options filenames)]
-    (fn
-      ([query params]
-       (conman/query queries query params))
-      ([conn query params & opts]
-       (apply conman/query conn queries query params opts)))))
+    {:mtimes (map ig-utils/last-modified filenames)
+     :query-fn (fn
+                 ([query params]
+                  (conman/query queries query params))
+                 ([conn query params & opts]
+                  (apply conman/query conn queries query params opts)))}))
+
+(defmethod ig/resolve-key :db.sql/query-fn [_ {:keys [query-fn]}]
+  query-fn)
+
+(defmethod ig/suspend-key! :db.sql/query-fn [_ _])
+
+(defmethod ig/resume-key :db.sql/query-fn
+  [k {:keys [filename filenames] :as opts} old-opts old-impl]
+  (if (and (= opts old-opts)
+           (= (map ig-utils/last-modified (or filenames [filename]))
+              (:mtimes old-impl)))
+    old-impl
+    (do (ig/halt-key! k old-impl)
+        (ig/init-key k opts))))


### PR DESCRIPTION
Perhaps this is overkill, but since a lot of your components will probably depend on the :db.sql/query-fn component the fact that it was not resumable caused pretty much all components to be reloaded when doing `(reset)`.

This PR adds an explicit check if any of the hugsql queries files are modified, and if not the old implementation is returned upon resume.

Requires Java 7+ since java.nio.file APIs are used for getting the modification time. (java.io.File#lastModified unfortunately always seem to return 0, at least on macOS).