### PR TITLE
Implement reitit reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ profiles.clj
 pom.xml.asc
 *.jar
 *.class
+*.bak
 .lein-*/
 .nrepl-port/
 .prepl-port/

--- a/libs/deps-template/resources/io/github/kit_clj/kit/gitignore
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/gitignore
@@ -12,6 +12,7 @@ modules/
 # IntelliJ
 *.iml
 .idea/
+*.bak
 
 # clj-kondo
 .clj-kondo/.cache/

--- a/libs/deps-template/resources/io/github/kit_clj/kit/resources/system.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/resources/system.edn
@@ -62,7 +62,8 @@
  {:routes #ig/refset :reitit/routes}
 
  :router/core
- {:routes #ig/ref :router/routes} <% if quartz? %>
+ {:routes #ig/ref :router/routes
+  :env #ig/ref :system/env} <% if quartz? %>
 
  :cronut/scheduler
  {:schedule []}<% endif %> <% if selmer? %>

--- a/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/handler.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/handler.clj
@@ -9,7 +9,7 @@
 (defmethod ig/init-key :handler/ring
   [_ {:keys [router api-path] :as opts}]
   (ring/ring-handler
-    router
+   (router)
     (ring/routes
      ;; Handle trailing slash in routes - add it + redirect to it
      ;; https://github.com/metosin/reitit/blob/master/doc/ring/slash_handler.md 
@@ -32,8 +32,15 @@
 
 (defmethod ig/init-key :router/routes
   [_ {:keys [routes]}]
-  (apply conj [] routes))
+  (mapv (fn [route]
+          (if (fn? route)
+            (route)
+            route))
+        routes))
 
 (defmethod ig/init-key :router/core
-  [_ {:keys [routes] :as opts}]
-  (ring/router ["" opts routes]))
+  [_ {:keys [routes env] :as opts}]
+  (let [router #(ring/router ["" opts routes])]
+    (if (= env :dev)
+      router
+      (constantly router))))

--- a/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/routes/api.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/routes/api.clj
@@ -46,4 +46,4 @@
   [_ {:keys [base-path]
       :or   {base-path ""}
       :as   opts}]
-  [base-path route-data (api-routes opts)])
+  (fn [] [base-path route-data (api-routes opts)]))


### PR DESCRIPTION
Fixes #48 by implementing reloading of routes as recommended by `reitit` in https://github.com/metosin/reitit/blob/master/doc/advanced/dev_workflow.md 

To take advantage of reloading, one has to return a function instead of a vector in his route definition. Check `(defmethod ig/init-key :reitit.routes/api` as an example.

The solution is backward compatible: it still accepts vectors as a route definition, but in that case no reloading.

The reloading is by default enabled only in `:dev` profile.

@yogthos , @nikolap please review before merging. I did some testing, but I'm not sure if there is a better/cleaner way to hook it up in integrant.