### PR TITLE
Add connection object as metadata to query-fn

### DIFF
--- a/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
+++ b/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
@@ -30,7 +30,8 @@
          (conman/query queries query params))
         ([conn query params & opts]
          (apply conman/query conn queries query params opts)))
-      {:mtimes (map ig-utils/last-modified filenames)})))
+      {:connection conn
+       :mtimes (map ig-utils/last-modified filenames)})))
 
 (defmethod ig/suspend-key! :db.sql/query-fn [_ _])
 


### PR DESCRIPTION
Since we already added some metadata to the query-fn I have found it useful to also have the db connection there as well, in particular when working with transactions (such as when using `next.jdbc/with-transaction`).

Prior to this change I need to pass the connection component ref to each component that uses transactions in addition to the (already somewhat onerous) query-fn ref. Passing one db-related object should be enough I think, and that the connection fits quite well in the query-fn metadata.

If you think this looks good I can also add some docs mentioning this and how to access it.