### PR TITLE
Bugfix on Conman

### DIFF
--- a/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
+++ b/libs/kit-sql-conman/src/kit/edge/db/sql/conman.clj
@@ -30,7 +30,7 @@
          (conman/query queries query params))
         ([conn query params & opts]
          (apply conman/query conn queries query params opts)))
-      {:mtimes (map ig-utils/last-modified filenames)})))
+      {:mtimes (doall (map ig-utils/last-modified filenames))})))
 
 (defmethod ig/suspend-key! :db.sql/query-fn [_ _])
 


### PR DESCRIPTION
@yogthos 

A few months ago you kindly accepted my PR to allow multiple hugsql scripts in system.edn.  The previous code inspects file edit time and if it has updated reloads conman.  Now that we have multiple files we have to map over all the file edit times but of course map is lazy.  As a result the previous edit times would get evaluated at the same time as the current one and never show any difference (!).  Very easy fix!

Matt