### PR TITLE
Add a dev clause for SQL queries automatic reload

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/resources/system.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/resources/system.edn
@@ -116,7 +116,8 @@
  :db.sql/query-fn
  {:conn     #ig/ref :db.sql/connection
   :options  {}
-  :filename "queries.sql"} <% endif %><% if migratus? %>
+  :filename "queries.sql"
+  :env #ig/ref :system/env} <% endif %><% if migratus? %>
 
  :db.sql/migrations
  {:store            :database


### PR DESCRIPTION
This MR changes the `query-fn` component allowing for auto-reload SQL queries if application operates on `:dev` profile.