### PR TITLE
Upgrade integrant to 0.9.0 version and use `expand` instead of `prep`

### DIFF
--- a/build/deps.edn
+++ b/build/deps.edn
@@ -1,7 +1,7 @@
 {:deps
  {;; kit-core
   aero/aero                              {:mvn/version "1.1.6"}
-  integrant/integrant                    {:mvn/version "0.8.1"}
+  integrant/integrant                    {:mvn/version "0.9.0"}
   org.clojure/tools.logging              {:mvn/version "1.2.4"}
   ch.qos.logback/logback-classic         {:mvn/version "1.4.11"}
   com.lambdaisland/classpath             {:mvn/version "0.4.44"}

--- a/build/kit/sync_lib_deps.clj
+++ b/build/kit/sync_lib_deps.clj
@@ -94,7 +94,7 @@
 (comment
   (def test-code
     "{:paths [\"src\"]
- :deps  {integrant/integrant       {:mvn/version \"0.7.0\"}
+ :deps  {integrant/integrant       {:mvn/version \"0.9.0\"}
          com.xtdb/xtdb-core        {:mvn/version \"1.20.0\"}}}")
 
   (replace-dependencies test-code dependencies))

--- a/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/user.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/user.clj
@@ -24,13 +24,13 @@
   []
   (integrant.repl/set-prep! (fn []
                               (-> (<<ns-name>>.config/system-config {:profile :dev})
-                                  (ig/prep)))))
+                                  (ig/expand)))))
 
 (defn test-prep!
   []
   (integrant.repl/set-prep! (fn []
                               (-> (<<ns-name>>.config/system-config {:profile :test})
-                                  (ig/prep)))))
+                                  (ig/expand)))))
 
 ;; Can change this to test-prep! if want to run tests as the test profile in your repl
 ;; You can run tests in the dev profile, too, but there are some differences between

--- a/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/core.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/core.clj
@@ -45,7 +45,7 @@
 (defn start-app [& [params]]
   ((or (:start params) (:start defaults) (fn [])))
   (->> (config/system-config (or (:opts params) (:opts defaults) {}))
-       (ig/prep)
+       (ig/expand)
        (ig/init)
        (reset! system))
   (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app)))

--- a/libs/kit-core/deps.edn
+++ b/libs/kit-core/deps.edn
@@ -1,5 +1,5 @@
 {:paths   ["src"]
  :deps    {aero/aero                      {:mvn/version "1.1.6"}
-           integrant/integrant            {:mvn/version "0.8.1"}
+           integrant/integrant            {:mvn/version "0.9.0"}
            org.clojure/tools.logging      {:mvn/version "1.2.4"}
            ch.qos.logback/logback-classic {:mvn/version "1.4.11"}}}

--- a/libs/kit-generator/test/resources/core.clj
+++ b/libs/kit-generator/test/resources/core.clj
@@ -34,7 +34,7 @@
 (defn start-app [& [params]]
   ((or (:start params) (:start defaults) (fn [])))
   (->> (config/system-config (or (:opts params) (:opts defaults) {}))
-       (ig/prep)
+       (ig/expand)
        (ig/init)
        (reset! system))
   (.addShutdownHook (Runtime/getRuntime) (Thread. stop-app)))

--- a/libs/kit-hato/deps.edn
+++ b/libs/kit-hato/deps.edn
@@ -1,3 +1,3 @@
 {:paths   ["src"]
- :deps    {integrant/integrant {:mvn/version "0.8.1"}
+ :deps    {integrant/integrant {:mvn/version "0.9.0"}
            hato/hato           {:mvn/version "1.0.0"}}}

--- a/libs/kit-http-kit/deps.edn
+++ b/libs/kit-http-kit/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
- :deps  {integrant/integrant {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant {:mvn/version "0.9.0"}
          http-kit/http-kit   {:mvn/version "2.7.0"}}}

--- a/libs/kit-http-kit/src/kit/edge/server/http_kit.clj
+++ b/libs/kit-http-kit/src/kit/edge/server/http_kit.clj
@@ -21,11 +21,11 @@
      (log/info "HTTP server stopped")
      result))
 
-(defmethod ig/prep-key :server/http-kit
-  [_ config]
-  (merge {:port 3000
-          :host "0.0.0.0"}
-         config))
+(defmethod ig/expand-key :server/http-kit
+  [k config]
+  {k (merge {:port 3000
+             :host "0.0.0.0"}
+            config)})
 
 (defmethod ig/init-key :server/http-kit
   [_ opts]

--- a/libs/kit-nrepl/deps.edn
+++ b/libs/kit-nrepl/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
  :deps  {org.clojure/tools.logging {:mvn/version "1.2.4"}
-         integrant/integrant       {:mvn/version "0.8.1"}
+         integrant/integrant       {:mvn/version "0.9.0"}
          nrepl/nrepl               {:mvn/version "1.1.1"}
          io.github.kit-clj/kit-core {:mvn/version "1.0.7"}}}

--- a/libs/kit-quartz/deps.edn
+++ b/libs/kit-quartz/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
  :deps  {aero/aero                  {:mvn/version "1.1.6"}
-         integrant/integrant        {:mvn/version "0.8.1"}
+         integrant/integrant        {:mvn/version "0.9.0"}
          com.troy-west/cronut       {:mvn/version "0.2.6"}
          io.github.kit-clj/kit-core {:mvn/version "1.0.7"}}}

--- a/libs/kit-redis/deps.edn
+++ b/libs/kit-redis/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {integrant/integrant        {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant        {:mvn/version "0.9.0"}
          org.clojure/core.cache     {:mvn/version "1.0.225"}
          com.taoensso/carmine       {:mvn/version "3.2.0"}
          io.github.kit-clj/kit-core {:mvn/version "1.0.7"}}}

--- a/libs/kit-repl/deps.edn
+++ b/libs/kit-repl/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
  :deps  {org.clojure/tools.logging {:mvn/version "1.2.4"}
-         integrant/integrant       {:mvn/version "0.8.1"}}}
+         integrant/integrant       {:mvn/version "0.9.0"}}}

--- a/libs/kit-repl/src/kit/edge/utils/repl.clj
+++ b/libs/kit-repl/src/kit/edge/utils/repl.clj
@@ -4,9 +4,9 @@
     [clojure.tools.logging :as log]
     [integrant.core :as ig]))
 
-(defmethod ig/prep-key :repl/server
-  [_ config]
-  (merge {:name "main"} config))
+(defmethod ig/expand-key :repl/server
+  [k config]
+  {k (merge {:name "main"} config)})
 
 (defmethod ig/init-key :repl/server
   [_ {:keys [port host name] :as config}]

--- a/libs/kit-selmer/deps.edn
+++ b/libs/kit-selmer/deps.edn
@@ -1,3 +1,3 @@
 {:paths   ["src"]
- :deps    {integrant/integrant {:mvn/version "0.8.1"}
+ :deps    {integrant/integrant {:mvn/version "0.9.0"}
            selmer/selmer       {:mvn/version "1.12.59"}}}

--- a/libs/kit-sql-conman/deps.edn
+++ b/libs/kit-sql-conman/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
- :deps  {integrant/integrant        {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant        {:mvn/version "0.9.0"}
          conman/conman              {:mvn/version "0.9.6"}
          io.github.kit-clj/kit-core {:mvn/version "1.0.7"}}}

--- a/libs/kit-sql-hikari/deps.edn
+++ b/libs/kit-sql-hikari/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps  {integrant/integrant               {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant               {:mvn/version "0.9.0"}
          com.github.seancorfield/next.jdbc {:mvn/version "1.3.883"} ;; TODO: is this required here?
          hikari-cp/hikari-cp               {:mvn/version "3.0.1"}
          io.github.kit-clj/kit-core        {:mvn/version "1.0.7"}}}

--- a/libs/kit-sql-migratus/deps.edn
+++ b/libs/kit-sql-migratus/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
- :deps  {integrant/integrant        {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant        {:mvn/version "0.9.0"}
          migratus/migratus          {:mvn/version "1.5.1"}}}

--- a/libs/kit-undertow/deps.edn
+++ b/libs/kit-undertow/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
  :deps  {org.clojure/tools.logging     {:mvn/version "1.2.4"}
-         integrant/integrant           {:mvn/version "0.8.1"}
+         integrant/integrant           {:mvn/version "0.9.0"}
          luminus/ring-undertow-adapter {:mvn/version "1.3.1"}}}

--- a/libs/kit-undertow/src/kit/edge/server/undertow.clj
+++ b/libs/kit-undertow/src/kit/edge/server/undertow.clj
@@ -16,11 +16,11 @@
   (.stop server)
   (log/info "HTTP server stopped"))
 
-(defmethod ig/prep-key :server/http
-  [_ config]
-  (merge {:port 3000
-          :host "0.0.0.0"}
-         config))
+(defmethod ig/expand-key :server/http
+  [k config]
+  {k (merge {:port 3000
+             :host "0.0.0.0"}
+            config)})
 
 (defmethod ig/init-key :server/http
   [_ opts]

--- a/libs/kit-xtdb/deps.edn
+++ b/libs/kit-xtdb/deps.edn
@@ -1,3 +1,3 @@
 {:paths ["src"]
- :deps  {integrant/integrant       {:mvn/version "0.8.1"}
+ :deps  {integrant/integrant       {:mvn/version "0.9.0"}
          com.xtdb/xtdb-core        {:mvn/version "1.23.0"}}}


### PR DESCRIPTION
This PR addresses https://github.com/kit-clj/kit/issues/138 by upgrading `integrant` library to `0.9.0` version both in core and kit-modules. 

It also replaces `ig/prep-key` with `ig/expand-key` as suggested in [integrant's README](https://github.com/weavejester/integrant/tree/master?tab=readme-ov-file#replacing-prep).

Subsequent changes on that matter may include documentation:
- https://kit-clj.github.io/docs/integrant.html
- https://kit-clj.github.io/docs/servers.html