### PR TITLE
cosmetic: trim whitespace in code files

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
@@ -13,7 +13,7 @@
 
            ;; Logging
            ch.qos.logback/logback-classic  {:mvn/version "1.5.7"}
-           
+
            ;; Data coercion
            luminus-transit/luminus-transit {:mvn/version "0.1.6"
                                             :exclusions [com.cognitect/transit-clj]}

--- a/libs/kit-generator/src/kit/generator/modules/generator.clj
+++ b/libs/kit-generator/src/kit/generator/modules/generator.clj
@@ -157,5 +157,3 @@
                                          :name "kit"}]
                          :modules      {:html {:path "html"}}}}]
     (generate ctx :html {:feature-flag :default})))
-
-    


### PR DESCRIPTION
trim whitespace specifically from 2 files:
- libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
- libs/kit-generator/src/kit/generator/modules/generator.clj

Note:
- it looks like more can probably be done for `libs/deps-template/resources/io/github/kit_clj/kit/deps.edn` to tidy things up a bit, but I am just choosing to tackle the whitespace-only line first to make for a better dev experience (when I open up `deps.edn` in my editor, this line is highlighted and makes me wonder; and I don't think this is unique to my editor (am using Emacs Prelude atm))
- I an choosing to ignore the trailing whitespace in CHANGELOG.md (but feel free to let me know if you want those to be removed as well so I can include it in this PR)