### PR TITLE
add a working request test to template

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
@@ -71,6 +71,8 @@
                                 ring/ring-mock                       {:mvn/version "0.4.0"}
                                 io.github.kit-clj/kit-generator      {:mvn/version "<<versions.kit-generator>>"}
                                 org.clojure/tools.namespace          {:mvn/version "1.4.5"}
+                                peridot/peridot                      {:mvn/version "0.5.4"}
+                                org.clj-commons/byte-streams         {:mvn/version "0.3.4"}
                                 com.lambdaisland/classpath           {:mvn/version "0.5.48"}}
                   :exec-fn      cognitect.test-runner.api/test
                   :extra-paths ["env/dev/clj" "env/dev/resources" "env/test/resources" "test/clj"]

--- a/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/test_utils.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/test_utils.clj
@@ -1,6 +1,8 @@
 (ns <<ns-name>>.test-utils
   (:require
     [<<ns-name>>.core :as core]
+    [peridot.core :as p]
+    [byte-streams :as bs]
     [integrant.repl.state :as state]))
 
 (defn system-state
@@ -14,3 +16,17 @@
       (core/start-app {:opts {:profile :test}}))
     (f)
     (core/stop-app)))
+
+(defn get-response [ctx]
+  (-> ctx
+      :response
+      (update :body (fnil bs/to-string ""))))
+
+(defn GET [app path params headers]
+  (-> (p/session app)
+      (p/request path
+                 :request-method :get
+                 :content-type "application/edn"
+                 :headers headers
+                 :params params)
+      (get-response)))

--- a/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/web/request_test.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/test/clj/web/request_test.clj
@@ -1,0 +1,15 @@
+(ns <<ns-name>>.web.request-test
+  (:require  [clojure.test :refer [deftest testing is use-fixtures]]
+             [<<ns-name>>.test-utils :refer [system-state system-fixture GET]]
+             [integrant.core :as ig]
+             [<<ns-name>>.config :as config]))
+
+(use-fixtures :once (system-fixture))
+
+(deftest health-request-test []
+  (testing "happy path"
+    (let [handler (:handler/ring (system-state))
+          params {}
+          headers {}
+          response (GET handler "/api/health" params headers)]
+      (is (= 200 (:status response))))))


### PR DESCRIPTION
This is a helping hand to get started with testing the ring app with mock requests. It should be especially helpful for beginners, as it isn't readily apparent how to do this. I figure since there is a handler in the template we might as well have a test for it. 

question: Should this be copied into the lein-template, or is there a way to avoid that?
question: Should byte-streams be added to the main dependencies? (I tend to add it all the time)

What do you think of this idea? 
Thanks!