### PR TITLE
remove `:persist-data? true` option from `env.clj` app defaults

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/env.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/env/dev/clj/env.clj
@@ -11,5 +11,4 @@
    :stop       (fn []
                  (log/info "\n-=[<<name>> has shut down successfully]=-"))
    :middleware wrap-dev
-   :opts       {:profile       :dev
-                :persist-data? true}})
+   :opts       {:profile       :dev}})


### PR DESCRIPTION
This pull requests is simply a removal of outdated artifact from previous versions that adds `:persist-data? true` to the application defaults.

Addressing issue: https://github.com/kit-clj/kit/issues/157 

