### PR TITLE
fix: resolve dependencies and install modules

### DIFF
--- a/libs/kit-generator/src/kit/api.clj
+++ b/libs/kit-generator/src/kit/api.clj
@@ -1,10 +1,11 @@
 (ns kit.api
   (:require
-    [clojure.string :as string]
-    [kit.generator.modules.generator :as generator]
-    [kit.generator.modules :as modules]
-    [kit.generator.snippets :as snippets]
-    [kit.generator.io :as io]))
+   [clojure.string :as string]
+   [kit.generator.modules.generator :as generator]
+   [kit.generator.modules.dependencies :as deps]
+   [kit.generator.modules :as modules]
+   [kit.generator.snippets :as snippets]
+   [kit.generator.io :as io]))
 
 ;; TODO: Add docstrings
 
@@ -36,9 +37,10 @@
   ([module-key {:keys [feature-flag] :as opts}]
    (let [{:keys [modules] :as ctx} (modules/load-modules (read-ctx))]
      (if (modules/module-exists? ctx module-key)
-       (let [module-config (generator/read-module-config ctx modules module-key)]
-         (println module-key "requires following modules:" (get-in module-config [feature-flag :requires]))
-         (doseq [module-key (get-in module-config [feature-flag :requires])]
+       (let [module-config (generator/read-module-config ctx modules module-key)
+             deps (deps/resolve-dependencies module-config  feature-flag)]
+         (println module-key "requires following modules:" deps)
+         (doseq [module-key deps]
            (install-dependency module-key))
          (generator/generate ctx module-key opts))
        (println "no module found with name:" module-key))

--- a/libs/kit-generator/src/kit/generator/modules/dependencies.clj
+++ b/libs/kit-generator/src/kit/generator/modules/dependencies.clj
@@ -1,17 +1,11 @@
 (ns kit.generator.modules.dependencies)
 
 (defn resolve-dependencies
-  ([module feature-flag modules]
-   (resolve-dependencies module feature-flag modules '()))
-  ([module feature-flag modules dependencies]
-   (let [requires (get-in module [feature-flag :requires])]
-     (if (empty? requires)
-       dependencies
-       (into requires (mapcat #(resolve-dependencies (get modules %) modules dependencies) requires))))))
-
-(comment
-  (let [module  {:default {:requires [:html]}}
-        modules {:db   {:requires [:foo :bar]}
-                 :html {:requires [:db]}}]
-    (resolve-dependencies module :default modules))
-  )
+  ([module-config feature-flag]
+   (resolve-dependencies module-config feature-flag #{}))
+  ([module-config feature-flag reqs]
+   (let [requires (get-in module-config [feature-flag :requires] [])
+         feature-requires (get-in module-config [feature-flag :feature-requires])]
+     (if feature-requires
+       (into #{} (mapcat #(resolve-dependencies (dissoc module-config feature-flag) % requires) feature-requires))
+       (into reqs requires)))))

--- a/libs/kit-generator/test/kit/generator/modules/dependencies_test.clj
+++ b/libs/kit-generator/test/kit/generator/modules/dependencies_test.clj
@@ -1,0 +1,26 @@
+(ns kit.generator.modules.dependencies-test
+  (:require [kit.generator.modules.dependencies :as deps]
+            [clojure.test :refer :all]))
+
+(deftest resolve-requires
+  (testing "empty requires"
+    (is (= #{} (deps/resolve-dependencies {:default {}} :default))))
+  (testing "simple default requires"
+    (is (= #{:a} (deps/resolve-dependencies {:default {:requires [:a]}} :default)))))
+
+(deftest resolve-feature-requires
+  (testing "simple feature requires"
+    (is (= #{:b} (deps/resolve-dependencies {:default {:feature-requires [:base]}
+                                             :base {:requires [:b]}} :default))))
+  (testing "double feature require"
+    (is (= #{:a :b} (deps/resolve-dependencies {:default {:feature-requires [:base :tool]}
+                                                :base {:requires [:a]}
+                                                :tool {:requires [:b]}} :default))))
+  (testing "feature requires another feature"
+    (is (= #{:a :b} (deps/resolve-dependencies {:default {:feature-requires [:base :tool]}
+                                                :base {:requires [:a]}
+                                                :tool {:requires [:b] :feature-requires [:base]}} :default))))
+  (testing "ciclic feature require"
+    (is (= #{:a :b} (deps/resolve-dependencies {:default {:feature-requires [:base :tool]}
+                                                :base {:requires [:a] :feature-requires [:tool]}
+                                                :tool {:requires [:b] :feature-requires [:base]}} :default)))))


### PR DESCRIPTION
Hi

I was trying `kit` and I run into this issue.

```bash
❯ clojure -Tclj-new create :template io.github.kit-clj :name luca/guestbook
Generating kit project.
❯ cd guestbook
❯ clj -M:dev
Clojure 1.12.0
user=> (kit/sync-modules)
:done
user=> (kit/install-module :kit/cljs)
:kit/cljs requires following modules: nil
applying features to config: [:base :reagent]
failed to read asset in project: resources/html/home.html
error: resources/html/home.html (No such file or directory)
updating file: resources/html/home.html
failed to install module :kit/cljs
java.lang.IllegalArgumentException: No method in multimethod 'get-resource' for dispatch value: null
	at clojure.lang.MultiFn.getFn(MultiFn.java:156)
	at clojure.lang.MultiFn.invoke(MultiFn.java:233)
	at net.cgrand.enlive_html$html_resource.invokeStatic(enlive_html.clj:69)
	at net.cgrand.enlive_html$html_resource.invoke(enlive_html.clj:66)
	at net.cgrand.enlive_html$html_resource.invokeStatic(enlive_html.clj:72)
	at net.cgrand.enlive_html$html_resource.invoke(enlive_html.clj:66)
	at kit.generator.modules.injections$eval10726$fn__10728.invoke(injections.clj:297)
	at clojure.lang.MultiFn.invoke(MultiFn.java:229)
	at kit.generator.modules.injections$inject_at_path$fn__10796.invoke(injections.clj:358)
	at clojure.lang.PersistentVector.reduce(PersistentVector.java:418)
	at clojure.core$reduce.invokeStatic(core.clj:6964)
	at clojure.core$reduce.invoke(core.clj:6947)
	at kit.generator.modules.injections$inject_at_path.invokeStatic(injections.clj:356)
	at kit.generator.modules.injections$inject_at_path.invoke(injections.clj:353)
	at kit.generator.modules.injections$inject_data.invokeStatic(injections.clj:375)
	at kit.generator.modules.injections$inject_data.invoke(injections.clj:368)
	at kit.generator.modules.generator$eval10911$fn__10913.invoke(generator.clj:67)
	at clojure.lang.MultiFn.invoke(MultiFn.java:234)
	at kit.generator.modules.generator$generate.invokeStatic(generator.clj:139)
	at kit.generator.modules.generator$generate.invoke(generator.clj:111)
	at kit.api$install_module.invokeStatic(api.clj:43)
	at kit.api$install_module.invoke(api.clj:33)
	at kit.api$install_module.invokeStatic(api.clj:35)
	at kit.api$install_module.invoke(api.clj:33)
	at user$eval26401.invokeStatic(NO_SOURCE_FILE:1)
	at user$eval26401.invoke(NO_SOURCE_FILE:1)
	at clojure.lang.Compiler.eval(Compiler.java:7700)
	at clojure.lang.Compiler.eval(Compiler.java:7655)
	at clojure.core$eval.invokeStatic(core.clj:3232)
	at clojure.core$eval.invoke(core.clj:3228)
	at clojure.main$repl$read_eval_print__9244$fn__9247.invoke(main.clj:437)
	at clojure.main$repl$read_eval_print__9244.invoke(main.clj:437)
	at clojure.main$repl$fn__9253.invoke(main.clj:459)
	at clojure.main$repl.invokeStatic(main.clj:459)
	at clojure.main$repl_opt.invokeStatic(main.clj:523)
	at clojure.main$main.invokeStatic(main.clj:668)
	at clojure.main$main.doInvoke(main.clj:617)
	at clojure.lang.RestFn.invoke(RestFn.java:400)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.RestFn.applyTo(RestFn.java:135)
	at clojure.lang.Var.applyTo(Var.java:707)
	at clojure.main.main(main.java:40)
:done
user=>
```

I looked at the `config.edn` for `:kit/cljs`
```clojure
{:default
 {:feature-requires [:base :reagent]}

 :base
 {:require-restart? true
  :actions
  {:assets     [["assets/shadow-cljs.edn" "shadow-cljs.edn"]]
   :injections [{:type   :html
                 :path   "resources/html/home.html"
                 :action :append
                 :target [:body]
                 :value  [:div {:id "app"}]}
                {:type   :html
                 :path   "resources/html/home.html"
                 :action :append
                 :target [:body]
                 :value  [:script {:src "/js/app.js"}]}
                {:type :edn
                 :path "deps.edn"
                 :target [:paths]
                 :action :append
                 :value "src/cljs"}
                {:type :edn
                 :path "deps.edn"
                 :target [:aliases :dev :extra-paths]
                 :action :append
                 :value  "target/classes/cljsbuild"}
                {:type   :edn
                 :path   "deps.edn"
                 :target [:aliases :build :deps]
                 :action :merge
                 :value  {babashka/fs {:mvn/version "0.1.11"}
                          babashka/process {:mvn/version "0.3.11"}}}
                {:type   :clj
                 :path   "build.clj"
                 :action :append-requires
                 :value  ["[babashka.fs :refer [copy-tree]]"
                          "[babashka.process :refer [shell]]"]}
                {:type   :clj
                 :path   "build.clj"
                 :action :append-build-task
                 :value  (defn build-cljs []
                           (println "npx shadow-cljs release app...")
                           (let [{:keys [exit]
                                  :as   s} (shell "npx shadow-cljs release app")]
                             (when-not (zero? exit)
                               (throw (ex-info "could not compile cljs" s)))
                             (copy-tree "target/classes/cljsbuild/public" "target/classes/public")))}
                {:type   :clj
                 :path   "build.clj"
                 :action :append-build-task-call
                 :value  (build-cljs)}]}}
 :reagent
 {:requires [:kit/html]
  :feature-requires [:base]

  :actions
  {:assets [["assets/src/core.cljs" "src/cljs/<<sanitized>>/core.cljs"]
            ["assets/package.json"    "package.json"]]
   :injections [{:type   :edn
                 :path   "shadow-cljs.edn"
                 :target [:dependencies]
                 :action :append
                 :value  [reagent "1.1.0"]}]}}

 :uix
 {:requires [:kit/html]
  :feature-requires [:base]
  :actions
  {:assets [["assets/src/core.uix.cljs" "src/cljs/<<sanitized>>/core.cljs"]
            ["assets/package.uix.json"    "package.json"]]
   :injections [{:type   :edn
                 :path   "shadow-cljs.edn"
                 :target [:dependencies]
                 :action :append
                 :value  [com.pitch/uix.core  "1.1.0"]}
                {:type :edn
                 :path "shadow-cljs.edn"
                 :target [:dependencies]
                 :action :append
                 :value [com.pitch/uix.dom  "1.1.0"]}]}}}
```

It looks like `:base` also need `:requires [:kit/html]`, I tried to fix that but didn't work.

I ended up looking into the code and find out we didn't resolve dependencies.

I tried to fix it 😄.