### PR TITLE
update kit.git-config.edn to match clj-jgit 1.0 syntax

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/kit.git-config.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/kit.git-config.edn
@@ -1,5 +1,3 @@
-{:name       "~/.ssh/id_rsa"
- :passphrase ""
- :options    {"StrictHostKeyChecking" "no"
-              "UserKnownHostsFile"    "/dev/null"}
- :exclusive  true}
+{:name       "id_rsa"
+ :pw         ""
+ :trust_all? true}


### PR DESCRIPTION
the syntax in the old template kit.git-config.edn was for a [previous version of clj-git](https://github.com/clj-jgit/clj-jgit/blob/2db54b995a6c5c2fd148bd30ceea520473f154da/src/clj_jgit/porcelain.clj#L1091-L1097). This matches the [new signature](https://github.com/clj-jgit/clj-jgit/blob/7c8c34a20ef78ebd65b4321251d946870f804b3a/src/clj_jgit/porcelain.clj#L201-L206).

[changed in this commit](https://github.com/clj-jgit/clj-jgit/commit/ca9ad94358fa2bbb76841f54a7602b971d228622)

Note, as someone new to clojure,  I can't get `(kit/sync-modules)` to work even with fixed syntax.