### PR TITLE
Update dependencies for reitit and ring-core

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/deps.edn
@@ -4,11 +4,11 @@
  :deps    {org.clojure/clojure             {:mvn/version "1.12.4"}
 
            ;; Routing
-           metosin/reitit                  {:mvn/version "0.10.0"}
+           metosin/reitit                  {:mvn/version "0.10.1"}
 
            ;; Ring
            metosin/ring-http-response      {:mvn/version "0.9.5"}
-           ring/ring-core                  {:mvn/version "1.15.3"}
+           ring/ring-core                  {:mvn/version "1.15.4"}
            ring/ring-defaults              {:mvn/version "0.7.0"}
 
            ;; Logging


### PR DESCRIPTION
Bump reitit to version 0.10.1 and ring-core to version 1.15.4 to
ensure compatibility with the latest features and improvements.