### PR TITLE
ClojureScript Template Output Fix

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/gitignore
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/gitignore
@@ -18,3 +18,4 @@ modules/
 .clj-kondo/.cache/
 .calva/output-window/
 .lsp/.cache/
+resources/public/js/

--- a/libs/kit-generator/test/resources/modules/kit/cljs/assets/build.clj
+++ b/libs/kit-generator/test/resources/modules/kit/cljs/assets/build.clj
@@ -2,6 +2,7 @@
   (:require [clojure.tools.build.api :as b]
             [clojure.string :as string]
             [clojure.java.shell :refer [sh]]
+            [babashka.fs :refer [copy-tree]]
             [deps-deploy.deps-deploy :as deploy]
             [kit.generator.io :as io]))
 
@@ -32,7 +33,9 @@
   (println "npx shadow-cljs release app-prod...")
   (let [{:keys [exit] :as s} (sh "npx" "shadow-cljs" "release" "app-prod")]
     (when-not (zero? exit)
-      (throw (ex-info "could not compile cljs" s)))))
+      (throw (ex-info "could not compile cljs" s)))
+    (b/delete {:path "target/classes/public/js"})
+    (copy-tree "target/classes/cljsbuild/public" "target/classes/public")))
 
 (defn uber [_]
   (b/compile-clj {:basis basis

--- a/libs/kit-generator/test/resources/modules/kit/cljs/assets/build.clj
+++ b/libs/kit-generator/test/resources/modules/kit/cljs/assets/build.clj
@@ -29,8 +29,8 @@
                :target-dir class-dir}))
 
 (defn build-cljs [_]
-  (println "npx shadow-cljs release app...")
-  (let [{:keys [exit] :as s} (sh "npx" "shadow-cljs" "release" "app")]
+  (println "npx shadow-cljs release app-prod...")
+  (let [{:keys [exit] :as s} (sh "npx" "shadow-cljs" "release" "app-prod")]
     (when-not (zero? exit)
       (throw (ex-info "could not compile cljs" s)))))
 

--- a/libs/kit-generator/test/resources/modules/kit/cljs/assets/shadow-cljs.edn
+++ b/libs/kit-generator/test/resources/modules/kit/cljs/assets/shadow-cljs.edn
@@ -5,7 +5,11 @@
                 [reagent "2.0.1"]
                 [cljs-ajax "0.8.4"]]
  :builds       {:app {:target     :browser
-                      :output-dir "target/classes/cljsbuild/public/js"
+                      :output-dir "resources/public/js"
                       :asset-path "/js"
                       :modules    {:app {:entries [<<ns-name>>.core]}}
-                      :devtools   {:after-load <<ns-name>>.core/mount-root}}}}
+                      :devtools   {:after-load <<ns-name>>.core/mount-root}}
+                :app-prod {:target     :browser
+                           :output-dir "target/classes/cljsbuild/public/js"
+                           :asset-path "/js"
+                           :modules    {:app {:entries [<<ns-name>>.core]}}}}}

--- a/libs/kit-generator/test/resources/modules/kit/cljs/config.edn
+++ b/libs/kit-generator/test/resources/modules/kit/cljs/config.edn
@@ -23,7 +23,8 @@
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-requires
-                 :value  ["[clojure.java.shell :refer [sh]]"]}
+                 :value  ["[clojure.java.shell :refer [sh]]"
+                          "[babashka.fs :refer [copy-tree]]"]}
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-build-task
@@ -32,7 +33,9 @@
                            (let [{:keys [exit]
                                   :as   s} (sh "npx" "shadow-cljs" "release" "app-prod")]
                              (when-not (zero? exit)
-                               (throw (ex-info "could not compile cljs" s)))))}
+                               (throw (ex-info "could not compile cljs" s)))
+                             (b/delete {:path "target/classes/public/js"})
+                             (copy-tree "target/classes/cljsbuild/public" "target/classes/public")))}
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-build-task-call

--- a/libs/kit-generator/test/resources/modules/kit/cljs/config.edn
+++ b/libs/kit-generator/test/resources/modules/kit/cljs/config.edn
@@ -28,9 +28,9 @@
                  :path   "build.clj"
                  :action :append-build-task
                  :value  (defn build-cljs []
-                           (println "npx shadow-cljs release app...")
+                           (println "npx shadow-cljs release app-prod...")
                            (let [{:keys [exit]
-                                  :as   s} (sh "npx" "shadow-cljs" "release" "app")]
+                                  :as   s} (sh "npx" "shadow-cljs" "release" "app-prod")]
                              (when-not (zero? exit)
                                (throw (ex-info "could not compile cljs" s)))))}
                 {:type   :clj


### PR DESCRIPTION
This change updates the Kit ClojureScript module template so development and production builds use different Shadow build IDs and output directories.


Generated projects include this in `resources/html/home.html`:

```html
<div id="app"></div>
<script src="/js/app.js"></script>
```

In development, `/js/app.js` must be available from project static resources, so the `:app` build should output to `resources/public/js`.

For production packaging, writing release artifacts into `resources/public/js` is not ideal because it mutates source resources. A dedicated production build target should write into a build output directory.


## What changed

1. `shadow-cljs.edn` template now has two build IDs:
   - `:app` -> `resources/public/js` (development/watch)
   - `:app-prod` -> `target/classes/cljsbuild/public/js` (release)

2. `build.clj` template release command now uses:

```clojure
(sh "npx" "shadow-cljs" "release" "app-prod")
```

It also removes stale copied JS output before the copy step:

```clojure
(b/delete {:path "target/classes/public/js"})
```

This avoids `FileAlreadyExistsException` on repeated `uberjar` runs (for example
when `target/classes/public/js/manifest.edn` already exists from a previous run).

3. The cljs module injection config was updated to append the same `app-prod` release command into generated `build.clj`.

4. The base generated `.gitignore` template now includes:

```gitignore
resources/public/js/
```

This keeps transient dev output out of git when running `npx shadow-cljs watch app`.