### PR TITLE
Fix http-response/content-type 

### DIFF
--- a/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/handler.clj
+++ b/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/handler.clj
@@ -2,7 +2,7 @@
   (:require
     [<<ns-name>>.web.middleware.core :as middleware]
     [integrant.core :as ig]
-    [ring.util.http-response :as http-response]
+    [ring.util.response :as response]
     [reitit.ring :as ring]
     [reitit.swagger-ui :as swagger-ui]))
 
@@ -21,13 +21,13 @@
      (ring/create-default-handler
       {:not-found
        (constantly (-> {:status 404, :body "Page not found"}
-                       (http-response/content-type "text/plain")))
+                       (response/content-type "text/plain")))
        :method-not-allowed
        (constantly (-> {:status 405, :body "Not allowed"}
-                       (http-response/content-type "text/plain")))
+                       (response/content-type "text/plain")))
        :not-acceptable
        (constantly (-> {:status 406, :body "Not acceptable"}
-                       (http-response/content-type "text/plain")))}))
+                       (response/content-type "text/plain")))}))
     {:middleware [(middleware/wrap-base opts)]}))
 
 (defmethod ig/init-key :router/routes


### PR DESCRIPTION
Updated the handler to use the correct response utility from the ring library.
This prevents clj-kondo warning`ring.util.http-response/content-type` unresolved var, although it is really available

https://github.com/metosin/ring-http-response
```md
created and not-found are same in both packages. Also rest of the public vars in ring.util.response are available via ring.util.http-response. These include: status, header, file-response, content-type, find-header, get-header, update-header, charset, set-cookie, response? resource-data, url-response and resource-response.

```